### PR TITLE
Ensure payment service test uses in-memory H2 datasource

### DIFF
--- a/payment-svc/src/test/java/hu/porkolab/chaosSymphony/payment/kafka/CanaryIntegrationTest.java
+++ b/payment-svc/src/test/java/hu/porkolab/chaosSymphony/payment/kafka/CanaryIntegrationTest.java
@@ -13,7 +13,16 @@ import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.datasource.username=sa",
+                "spring.datasource.password=",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+        }
+)
 @DirtiesContext
 @EmbeddedKafka(partitions = 1, topics = { "payment.requested", "payment.requested.canary" })
 class CanaryIntegrationTest {


### PR DESCRIPTION
## Summary
- configure CanaryIntegrationTest to explicitly use an in-memory H2 datasource so CI isn't affected by external SPRING_DATASOURCE_URL settings

## Testing
- `mvn -q -pl payment-svc -am test` *(fails: Non-resolvable parent POM due to network is unreachable)*
